### PR TITLE
Patterns don't use /

### DIFF
--- a/src/Json/Validator.php
+++ b/src/Json/Validator.php
@@ -500,7 +500,7 @@ class Validator
     protected function checkPattern($entity, $schema, $entityName)
     {
         if (isset($schema->pattern) && $schema->pattern) {
-            if (!preg_match($schema->pattern, $entity)) {
+            if (!preg_match('/' . $schema->pattern . '/', $entity)) {
                 throw new ValidationException(sprintf('String does not match pattern for [%s]', $entityName));
             }
         }

--- a/tests/mock/pattern.json
+++ b/tests/mock/pattern.json
@@ -1,4 +1,4 @@
 {
     "type" : "string",
-    "pattern" : "/^[A-Z]+$/"
+    "pattern" : "^[A-Z]+$"
 }


### PR DESCRIPTION
According to the examples I've seen on mailing lists, JSON Schema's patterns look like this:

``` javascript
{
    "type": "string",
    "pattern": "^[a-zA-Z]*$"
}
```

Your tests assume they start and end with a slash.
