### PR TITLE
PHP considers somthing numeric which is not in JavaScript

### DIFF
--- a/src/Json/Validator.php
+++ b/src/Json/Validator.php
@@ -218,19 +218,19 @@ class Validator
                     }
                     break;
                 case 'integer':
-                    if (is_int($entity)) {
+                    if (!is_string($entity) && is_int($entity)) {
                         $this->checkTypeInteger($entity, $schema, $entityName);
                         $valid = true;
                     }
                     break;
                 case 'number':
-                    if (is_numeric($entity)) {
+                    if (!is_string($entity) && is_numeric($entity)) {
                         $this->checkTypeNumber($entity, $schema, $entityName);
                         $valid = true;
                     }
                     break;
                 case 'boolean':
-                    if (is_bool($entity)) {
+                    if (!is_string($entity) && is_bool($entity)) {
                         $this->checkTypeBoolean($entity, $schema, $entityName);
                         $valid = true;
                     }


### PR DESCRIPTION
In Javascript:

```
typeof "2" => returns a "string"
typeof 2 => returns "number"
```

In PHP:

```
is_numeric("2") => returns true
is_numeric(2) => returns true
```

What I want to say is what PHP considers something numeric it is not always numeric in other languages.
